### PR TITLE
Changes for gnome 3-14

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -270,14 +270,14 @@ function enable() {
     if (!trackerSearchProviderFiles) {
         trackerSearchProviderFiles = new TrackerSearchProvider("FILES", CategoryType.FTS);
         //Main.overview.addSearchProvider(trackerSearchProviderFiles);
-        Main.overview.viewSelector._searchResults._searchSystem.addProvider(trackerSearchProviderFiles);
+        Main.overview.viewSelector._searchResults._registerProvider(trackerSearchProviderFiles);
     }
 }
 
 function disable() {
     if (trackerSearchProviderFiles){
         //Main.overview.removeSearchProvider(trackerSearchProviderFiles);
-        Main.overview.viewSelector._searchResults._searchSystem._unregisterProvider(trackerSearchProviderFiles);
+        Main.overview.viewSelector._searchResults._unregisterProvider(trackerSearchProviderFiles);
         trackerSearchProviderFiles = null;
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -2,6 +2,6 @@
   "uuid": "tracker-search-provider@sinnix.de",
   "name": "Tracker Search Provider",
   "description": "Provide tracker search results in overview",
-			  "shell-version": ["3.12"],
+  "shell-version": ["3.14"],
   "url": "https://github.com/hamiller/tracker-search-provider"
 }


### PR DESCRIPTION
Changed a couple of lines, now working in Debian Jessie, GNOME 3.14.1:
addProvider was changed to _registerProvider

It's probably now broken for 3.12, so this should be a separate branch
