### PR TITLE
Use MAX_RESULTS constant to display the right number of results

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -241,7 +241,7 @@ const TrackerSearchProvider = new Lang.Class({
     },
 
     filterResults : function(results, max) {
-        return results.slice(0, 5);
+        return results.slice(0, MAX_RESULTS);
     },
 
     launchSearch: function(terms) {


### PR DESCRIPTION
So we are sure to display the asked number of results.

Should we use the minimal value between the  `max` function argument and `MAX_RESULTS` ?

I didn't find any documentation here: https://developer.gnome.org/shell/stable/gdbus-org.gnome.Shell.SearchProvider2.html about that function.
