### PR TITLE
Allow execution on Gnome 3.18

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,6 +2,6 @@
   "uuid": "tracker-search-provider@sinnix.de",
   "name": "Tracker Search Provider",
   "description": "Provide tracker search results in overview",
-  "shell-version": ["3.16"],
+  "shell-version": ["3.18"],
   "url": "https://github.com/hamiller/tracker-search-provider"
 }


### PR DESCRIPTION
Fix #17 : it seems the gnome_16 branch just work with Gnome 3.18.
