### PR TITLE
Updates to work with Gnome Shell 3.18

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -183,7 +183,11 @@ const TrackerSearchProvider = new Lang.Class({
         } catch (error) {
             //global.log("TrackerSearchProvider: Could not traverse results cursor: " + error.message);
         }
-        this.searchSystem.setResults(this, results);
+        if (this.searchSystem) {
+            this.searchSystem.setResults(this, results);
+        } else {
+            callback(results);
+        }
     },
 
     _connection_ready : function(object, result, terms, filetype, callback) {
@@ -263,13 +267,25 @@ function init() {
 function enable() {
     if (!trackerSearchProviderFiles) {
         trackerSearchProviderFiles = new TrackerSearchProvider("FILES", CategoryType.FTS);
-        Main.overview.addSearchProvider(trackerSearchProviderFiles);
+        if (Main.overview.viewSelector && Main.overview.viewSelector._searchResults && Main.overview.viewSelector._searchResults._searchSystem) {
+            Main.overview.viewSelector._searchResults._searchSystem.addProvider(trackerSearchProviderFiles)
+        } else if (Main.overview.viewSelector && Main.overview.viewSelector._searchResults && Main.overview.viewSelector._searchResults._registerProvider) {
+            Main.overview.viewSelector._searchResults._registerProvider(trackerSearchProviderFiles);
+        } else {
+            Main.overview.addSearchProvider(trackerSearchProviderFiles);
+        }
     }
 }
 
 function disable() {
     if (trackerSearchProviderFiles){
-        Main.overview.removeSearchProvider(trackerSearchProviderFiles);
+        if (Main.overview.viewSelector && Main.overview.viewSelector._searchResults && Main.overview.viewSelector._searchResults._searchSystem) {
+            Main.overview.viewSelector._searchResults._searchSystem._unregisterProvider(trackerSearchProviderFiles)
+        } else if (Main.overview.viewSelector && Main.overview.viewSelector._searchResults && Main.overview.viewSelector._searchResults._registerProvider) {
+            Main.overview.viewSelector._searchResults._unregisterProvider(trackerSearchProviderFiles);
+        } else {
+            Main.overview.removeSearchProvider(trackerSearchProviderFiles);
+        }
         trackerSearchProviderFiles = null;
     }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -2,6 +2,6 @@
   "uuid": "tracker-search-provider@sinnix.de",
   "name": "Tracker Search Provider",
   "description": "Provide tracker search results in overview",
-  "shell-version": ["3.10"],
+  "shell-version": ["3.18"],
   "url": "https://github.com/hamiller/tracker-search-provider"
 }


### PR DESCRIPTION
Some tweaks to make the tracker search provider work with GS 3.18's changed way of doing search providers.